### PR TITLE
Add width property in Button component

### DIFF
--- a/src/components/common/Button/Button.jsx
+++ b/src/components/common/Button/Button.jsx
@@ -38,6 +38,12 @@ const ButtonWrapper = styled.button`
     color: ${({ theme }) => theme.colors.white};
     cursor: not-allowed;
   }
+
+  ${({ width }) =>
+    width &&
+    css`
+      width: ${width}px;
+    `}
 `;
 
 const variantStyles = {
@@ -98,6 +104,7 @@ const Button = ({
   size = 40,
   state = "enabled",
   image = null,
+  width,
   children = null,
   onClick,
 }) => {
@@ -105,6 +112,7 @@ const Button = ({
     <ButtonWrapper
       variant={variant}
       size={size}
+      width={width}
       onClick={onClick}
       disabled={state === "disabled"}
     >

--- a/src/components/common/Button/IconButton.jsx
+++ b/src/components/common/Button/IconButton.jsx
@@ -21,6 +21,12 @@ const IconButtonWrapper = styled.button`
     background-color: ${({ theme }) => theme.colors.grayScale[300]};
     cursor: not-allowed;
   }
+
+  ${({ width }) =>
+    width &&
+    css`
+      width: ${width}px;
+    `}
 `;
 
 const imageMap = {
@@ -30,7 +36,11 @@ const imageMap = {
 
 const IconButton = ({ image, onClick, state = "enabled" }) => {
   return (
-    <IconButtonWrapper onClick={onClick} disabled={state === "disabled"}>
+    <IconButtonWrapper
+      onClick={onClick}
+      width={width}
+      disabled={state === "disabled"}
+    >
       <img src={imageMap[image]} alt="icon" style={{ width: 24, height: 24 }} />
     </IconButtonWrapper>
   );


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 PR 유형
<!-- 해당하는 유형에 'x'로 체크해주세요 -->
- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항
<!-- 이 PR에서 무엇이 변경되었는지 간략하게 설명해주세요 -->
버튼 컴포넌트에 자동 적용되는 패딩 이외로 width가 새롭게 적용되는 경우가 많아 width property를 새로 추가했습니다. 컴포넌트 사용할 때 width={280} 요런 식으로 추가해주면 되어요 ~~

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## 🛠️ 테스트 방법
<!-- 이 기능을 테스트하는 방법을 설명해주세요 -->
```
          <Button
            variant="primary"
            size="56"
            width={280}
            onClick={() => navigate("/list")}
          >
            구경해보기
          </Button>
```
- 요런 식으로 width 지정해주면 됩니다

## 🚧 관련 이슈
<!-- 관련 이슈 번호가 있다면 적어주세요 (e.g. #123 또는 ISSUE-123 과 같은 JIRA key) -->

## 💡 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요 -->

## 🙏 리뷰어에게
<!-- 리뷰어에게 특별히 확인받고 싶은 부분이 있다면 언급해주세요 -->