### PR TITLE
SCRUM-76-김수연-list 페이지 이모티콘 제외 완료

### DIFF
--- a/src/components/common/Button/ArrowButton.jsx
+++ b/src/components/common/Button/ArrowButton.jsx
@@ -10,7 +10,12 @@ const ArrowButtonWrapper = styled.button`
   width: 40px;
   height: 40px;
   border-radius: 50%;
-  background-color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(
+    255,
+    255,
+    255,
+    0.5
+  ); // 색깔만 바꿨어요 조금만 더 투명으로
   border: 1px solid ${({ theme }) => theme.colors.grayScale[300]};
   box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.08);
   backdrop-filter: blur(4px);

--- a/src/components/common/Input/Input/Input.jsx
+++ b/src/components/common/Input/Input/Input.jsx
@@ -13,9 +13,7 @@ import Button from "../../Button/Button";
 import recipientsService from "../../../../api/services/recipientsService"; // post 해줘야 함
 
 export const Bone = styled.div`
-  margin: 3.562rem auto;
   width: 45rem;
-  height: 33.875rem;
 `;
 
 const Picker = styled.div`

--- a/src/components/domain/rollingpaper/Card/CardWrite.jsx
+++ b/src/components/domain/rollingpaper/Card/CardWrite.jsx
@@ -6,7 +6,7 @@ import ReactQuill from "react-quill";
 import "react-quill/dist/quill.snow.css";
 import "../../../../styles/font.css";
 import Modal from "./Modal";
-
+import Badge from "../../../common/Badge/Badge";
 const Quill = ReactQuill.Quill;
 var Font = Quill.import("formats/font");
 Font.whitelist = [
@@ -20,7 +20,7 @@ const EditorWrapper = styled.div.withConfig({
 })`
   .ql-editor {
     width: 336px;
-    min-height: 106px;
+    max-height: 106px;
     font-size: 1rem !important;
     line-height: 28px;
     padding: 16px 0;
@@ -145,7 +145,7 @@ const CardWrite = ({ message }) => {
               <From>From.</From>
               <Name>{message.sender}</Name>
             </NameWrap>
-            <Tag>{message.relationship}</Tag>
+            <Badge relationship={message.relationship} />
           </div>
         </Header>
         <EditorWrapper

--- a/src/components/domain/rollingpaper/Card/CreateAtCardList.jsx
+++ b/src/components/domain/rollingpaper/Card/CreateAtCardList.jsx
@@ -168,10 +168,10 @@ function CreateAtCardList() {
         );
 
         const updatedRecipients = sortedRecipients.map((recipient) => {
-          const images = recipient.recentMessages?.slice(0, 3) || []; // recentMessages가 undefined일 경우 빈 배열 반환
+          const images = recipient.recentMessages?.slice(0, 3) || [];
           const imageUrls = images
             .map((msg) => msg.profileImageURL)
-            .filter(Boolean); // undefined 방지
+            .filter(Boolean);
           return {
             ...recipient,
             profileImages: imageUrls,

--- a/src/components/domain/rollingpaper/Card/CreateAtCardList.jsx
+++ b/src/components/domain/rollingpaper/Card/CreateAtCardList.jsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import { useEffect, useState } from "react";
 import recipientsService from "../../../../api/services/recipientsService";
 import ArrowButton from "../../../common/Button/ArrowButton";
+import { useNavigate } from "react-router-dom";
 
 const BoneWrap = styled.div`
   width: 1160px;
@@ -44,6 +45,19 @@ const BackgroundWrap = styled.div.withConfig({
   color: ${({ backgroundImageURL }) =>
     backgroundImageURL ? "#ffffff;" : "#000000"};
   position: relative;
+  transition: transform 0.3s ease, box-shadow 0.3s ease,
+    background-color 0.3s ease;
+
+  &:hover {
+    transform: scale(1);
+    box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.2);
+    cursor: pointer;
+  }
+
+  &:active {
+    transform: scale(0.98);
+    box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.3);
+  }
 `;
 const TextDisplay = styled.div`
   display: flex;
@@ -114,26 +128,35 @@ const ArrowButtonDisplay = styled.div`
 `;
 
 const LeftArrowButtonDisplay = styled(ArrowButtonDisplay)`
-  position: relative;
-  right: -38px;
-  top: 118px;
+  position: absolute;
+  left: 186px; // 왼쪽에 위치하도록 설정
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 1;
+  display: ${({ show }) => (show ? "block" : "none")};
 `;
 
 const RightArrowButtonDisplay = styled(ArrowButtonDisplay)`
-  position: relative;
-  left: -38px;
-  top: 118px;
+  position: absolute;
+  right: 186px; // 오른쪽에 위치하도록 설정
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 1;
+  display: ${({ show }) => (show ? "block" : "none")};
 `;
+
 function CreateAtCardList() {
   const [selectedRecipients, setSelectedRecipients] = useState([]);
   const [scrollPosition, setScrollPosition] = useState(0);
   const cardWidth = 295;
+  const navigate = useNavigate(); // useNavigate 훅 사용
   const colorMap = {
     beige: "#FFE2AD",
     purple: "#ECD9FF",
     blue: "#B1E4FF",
     green: "#D0F5C3",
   };
+
   useEffect(() => {
     const loadRecipients = async () => {
       try {
@@ -176,9 +199,20 @@ function CreateAtCardList() {
     setScrollPosition((prev) => (prev < 0 ? prev + 2 * cardWidth : 0));
   };
 
+  const handleCardClick = (id) => {
+    // 클릭 시 해당 id로 페이지 이동
+    navigate(`/post/${id}`);
+  };
+
+  // 좌측 버튼 숨기기 조건
+  const showLeftButton = scrollPosition !== 0;
+  // 우측 버튼 숨기기 조건
+  const showRightButton =
+    scrollPosition > -(selectedRecipients.length * cardWidth - 1160);
+
   return (
     <>
-      <LeftArrowButtonDisplay>
+      <LeftArrowButtonDisplay show={showLeftButton}>
         <ArrowButton
           direction="left"
           onClick={handlePrev}
@@ -193,6 +227,7 @@ function CreateAtCardList() {
                 key={index}
                 bgColor={colorMap[recipient.backgroundColor] || "#FFFFFF"}
                 backgroundImageURL={recipient.backgroundImageURL || null}
+                onClick={() => handleCardClick(recipient.id)} // 클릭 시 해당 id로 이동
               >
                 <div>
                   <TextDisplay>
@@ -223,7 +258,7 @@ function CreateAtCardList() {
           </Bone>
         </BoneContainer>
       </BoneWrap>
-      <RightArrowButtonDisplay>
+      <RightArrowButtonDisplay show={showRightButton}>
         <ArrowButton
           direction="right"
           onClick={handleNext}

--- a/src/components/domain/rollingpaper/Card/CreateAtCardList.jsx
+++ b/src/components/domain/rollingpaper/Card/CreateAtCardList.jsx
@@ -1,0 +1,239 @@
+import "../../../../styles/GlobalStyles";
+import { textStyle } from "../../../../styles/textStyle";
+import styled from "styled-components";
+import { useEffect, useState } from "react";
+import recipientsService from "../../../../api/services/recipientsService";
+import ArrowButton from "../../../common/Button/ArrowButton";
+
+const BoneWrap = styled.div`
+  width: 1160px;
+  position: relative;
+  overflow: hidden;
+`;
+
+const BoneContainer = styled.div`
+  display: flex;
+  align-items: center;
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+`;
+
+const Bone = styled.div`
+  display: flex;
+  gap: 20px;
+  width: fit-content;
+  transition: transform 0.5s ease;
+  transform: translateX(${(props) => props.scrollPosition}px);
+`;
+
+const BackgroundWrap = styled.div.withConfig({
+  shouldForwardProp: (prop) =>
+    !["bgColor", "backgroundImageURL"].includes(prop),
+})`
+  background-color: ${({ bgColor }) => bgColor || "#FFFFFF"};
+  background-image: ${({ backgroundImageURL }) =>
+    backgroundImageURL ? `url(${backgroundImageURL})` : "none"};
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  width: 275px;
+  height: 260px;
+  padding: 30px 24px;
+  border-radius: 1rem;
+  color: ${({ backgroundImageURL }) =>
+    backgroundImageURL ? "#ffffff;" : "#000000"};
+  position: relative;
+`;
+const TextDisplay = styled.div`
+  display: flex;
+  height: 36px;
+  margin-bottom: 0.75rem;
+`;
+
+const ToText = styled.div`
+  ${(props) => textStyle(24, 700)(props)}
+  margin-bottom: 0.75rem;
+  height: 2.625rem;
+`;
+
+const WritedContainer = styled.div`
+  display: inline-flex;
+  align-items: center;
+`;
+
+const Avatar = styled.div`
+  ${(props) => textStyle(12, 400)(props)}
+  right: -6px;
+  position: relative;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background-color: white;
+  border: 1px solid ${({ theme }) => theme.colors.grayScale[200]};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: -10px;
+  margin-bottom: 0.75rem;
+
+  img {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+  }
+
+  &:not(:has(img)) {
+    background-color: white;
+    color: ${({ theme }) => theme.colors.grayScale[800]};
+  }
+`;
+
+const WriteCount = styled.div`
+  font-size: 16px;
+  font-weight: 600;
+`;
+
+const WriteCountDisplay = styled.div`
+  display: flex;
+  align-items: center;
+  ${(props) => textStyle(16, 700)(props)}
+`;
+
+const WritedText = styled.div`
+  font-size: 14px;
+`;
+
+const ArrowButtonDisplay = styled.div`
+  display: flex;
+  align-items: center;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 1;
+`;
+
+const LeftArrowButtonDisplay = styled(ArrowButtonDisplay)`
+  position: relative;
+  right: -38px;
+  top: 118px;
+`;
+
+const RightArrowButtonDisplay = styled(ArrowButtonDisplay)`
+  position: relative;
+  left: -38px;
+  top: 118px;
+`;
+function CreateAtCardList() {
+  const [selectedRecipients, setSelectedRecipients] = useState([]);
+  const [scrollPosition, setScrollPosition] = useState(0);
+  const cardWidth = 295;
+  const colorMap = {
+    beige: "#FFE2AD",
+    purple: "#ECD9FF",
+    blue: "#B1E4FF",
+    green: "#D0F5C3",
+  };
+  useEffect(() => {
+    const loadRecipients = async () => {
+      try {
+        const response = await recipientsService.getRecipients(
+          "/14-8/recipients/"
+        );
+        const sortedRecipients = response.data.results.sort(
+          (a, b) => new Date(b.createdAt) - new Date(a.createdAt)
+        );
+
+        const updatedRecipients = sortedRecipients.map((recipient) => {
+          const images = recipient.recentMessages?.slice(0, 3) || []; // recentMessages가 undefined일 경우 빈 배열 반환
+          const imageUrls = images
+            .map((msg) => msg.profileImageURL)
+            .filter(Boolean); // undefined 방지
+          return {
+            ...recipient,
+            profileImages: imageUrls,
+          };
+        });
+
+        console.log(updatedRecipients);
+        setSelectedRecipients(updatedRecipients);
+      } catch (error) {
+        console.error("받는 사람 데이터를 가져오지 못했습니다:", error);
+      }
+    };
+
+    loadRecipients();
+  }, []);
+
+  const handleNext = () => {
+    const maxScroll = -(selectedRecipients.length * cardWidth - 1160);
+    setScrollPosition((prev) =>
+      prev > maxScroll ? prev - 2 * cardWidth : maxScroll
+    );
+  };
+
+  const handlePrev = () => {
+    setScrollPosition((prev) => (prev < 0 ? prev + 2 * cardWidth : 0));
+  };
+
+  return (
+    <>
+      <LeftArrowButtonDisplay>
+        <ArrowButton
+          direction="left"
+          onClick={handlePrev}
+          disabled={scrollPosition === 0}
+        />
+      </LeftArrowButtonDisplay>
+      <BoneWrap>
+        <BoneContainer>
+          <Bone scrollPosition={scrollPosition}>
+            {selectedRecipients.map((recipient, index) => (
+              <BackgroundWrap
+                key={index}
+                bgColor={colorMap[recipient.backgroundColor] || "#FFFFFF"}
+                backgroundImageURL={recipient.backgroundImageURL || null}
+              >
+                <div>
+                  <TextDisplay>
+                    <ToText>To.</ToText>
+                    <ToText>
+                      {recipient.name === "Unknown"
+                        ? "이름 없음"
+                        : recipient.name}
+                    </ToText>
+                  </TextDisplay>
+                  <WritedContainer>
+                    {recipient.profileImages?.slice(0, 3).map((url, i) => (
+                      <Avatar key={i}>
+                        <img src={url} alt={`프로필 이미지 ${i + 1}`} />
+                      </Avatar>
+                    ))}
+                    {recipient.messageCount > 3 && (
+                      <Avatar>+{recipient.messageCount - 3}</Avatar>
+                    )}
+                  </WritedContainer>
+                  <WriteCountDisplay>
+                    <WriteCount>{recipient.messageCount}</WriteCount>
+                    <WritedText>명이 작성했어요!</WritedText>
+                  </WriteCountDisplay>
+                </div>
+              </BackgroundWrap>
+            ))}
+          </Bone>
+        </BoneContainer>
+      </BoneWrap>
+      <RightArrowButtonDisplay>
+        <ArrowButton
+          direction="right"
+          onClick={handleNext}
+          disabled={
+            scrollPosition <= -(selectedRecipients.length * cardWidth - 1160)
+          }
+        />
+      </RightArrowButtonDisplay>
+    </>
+  );
+}
+
+export default CreateAtCardList;

--- a/src/components/domain/rollingpaper/Card/CreateAtCardList.jsx
+++ b/src/components/domain/rollingpaper/Card/CreateAtCardList.jsx
@@ -5,7 +5,6 @@ import { useEffect, useState } from "react";
 import recipientsService from "../../../../api/services/recipientsService";
 import ArrowButton from "../../../common/Button/ArrowButton";
 import { useNavigate } from "react-router-dom";
-
 const BoneWrap = styled.div`
   width: 1160px;
   position: relative;
@@ -26,6 +25,7 @@ const Bone = styled.div`
   width: fit-content;
   transition: transform 0.5s ease;
   transform: translateX(${(props) => props.scrollPosition}px);
+  position: relative;
 `;
 
 const BackgroundWrap = styled.div.withConfig({
@@ -119,37 +119,36 @@ const WritedText = styled.div`
 `;
 
 const ArrowButtonDisplay = styled.div`
-  display: flex;
-  align-items: center;
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  z-index: 1;
+align-items: center;
+   
+    transform: translateY(40%);
+    z-index: 2;
+    transform: matrix(1, 0, 0, 1, 0, 108);
+    transition: opacity 0.3s ease;
+}
 `;
-
 const LeftArrowButtonDisplay = styled(ArrowButtonDisplay)`
-  position: absolute;
-  left: 186px; // 왼쪽에 위치하도록 설정
-  top: 50%;
-  transform: translateY(-50%);
-  z-index: 1;
   display: ${({ show }) => (show ? "block" : "none")};
+  position: relative;
+  left: 38px;
+  top: 23%;
+  transform: translateY(42%);
+  z-index: 1;
 `;
 
 const RightArrowButtonDisplay = styled(ArrowButtonDisplay)`
-  position: absolute;
-  right: 186px; // 오른쪽에 위치하도록 설정
-  top: 50%;
-  transform: translateY(-50%);
+  position: relative;
+  right: 38px;
+  top: 23%;
+  transform: translateY(42%);
   z-index: 1;
-  display: ${({ show }) => (show ? "block" : "none")};
+  display: block;
 `;
-
 function CreateAtCardList() {
   const [selectedRecipients, setSelectedRecipients] = useState([]);
   const [scrollPosition, setScrollPosition] = useState(0);
   const cardWidth = 295;
-  const navigate = useNavigate(); // useNavigate 훅 사용
+  const navigate = useNavigate();
   const colorMap = {
     beige: "#FFE2AD",
     purple: "#ECD9FF",
@@ -164,7 +163,7 @@ function CreateAtCardList() {
           "/14-8/recipients/"
         );
         const sortedRecipients = response.data.results.sort(
-          (a, b) => new Date(b.createdAt) - new Date(a.createdAt)
+          (a, b) => b.createdAt - a.createdAt
         );
 
         const updatedRecipients = sortedRecipients.map((recipient) => {

--- a/src/components/domain/rollingpaper/Card/PopularCardList.jsx
+++ b/src/components/domain/rollingpaper/Card/PopularCardList.jsx
@@ -5,7 +5,6 @@ import { useEffect, useState } from "react";
 import recipientsService from "../../../../api/services/recipientsService";
 import ArrowButton from "../../../common/Button/ArrowButton";
 import { useNavigate } from "react-router-dom";
-
 const BoneWrap = styled.div`
   width: 1160px;
   position: relative;
@@ -26,6 +25,7 @@ const Bone = styled.div`
   width: fit-content;
   transition: transform 0.5s ease;
   transform: translateX(${(props) => props.scrollPosition}px);
+  position: relative;
 `;
 
 const BackgroundWrap = styled.div.withConfig({
@@ -119,37 +119,36 @@ const WritedText = styled.div`
 `;
 
 const ArrowButtonDisplay = styled.div`
-  display: flex;
-  align-items: center;
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  z-index: 1;
+align-items: center;
+   
+    transform: translateY(40%);
+    z-index: 2;
+    transform: matrix(1, 0, 0, 1, 0, 108);
+    transition: opacity 0.3s ease;
+}
 `;
-
 const LeftArrowButtonDisplay = styled(ArrowButtonDisplay)`
-  position: absolute;
-  left: 186px; // 왼쪽에 위치하도록 설정
-  top: 23%;
-  transform: translateY(-50%);
-  z-index: 1;
   display: ${({ show }) => (show ? "block" : "none")};
+  position: relative;
+  left: 38px;
+  top: 23%;
+  transform: translateY(42%);
+  z-index: 1;
 `;
 
 const RightArrowButtonDisplay = styled(ArrowButtonDisplay)`
-  position: absolute;
-  right: 186px; // 오른쪽에 위치하도록 설정
+  position: relative;
+  right: 38px;
   top: 23%;
-  transform: translateY(-50%);
+  transform: translateY(42%);
   z-index: 1;
-  display: ${({ show }) => (show ? "block" : "none")};
+  display: block;
 `;
-
 function CreateAtCardList() {
   const [selectedRecipients, setSelectedRecipients] = useState([]);
   const [scrollPosition, setScrollPosition] = useState(0);
   const cardWidth = 295;
-  const navigate = useNavigate(); // useNavigate 훅 사용
+  const navigate = useNavigate();
   const colorMap = {
     beige: "#FFE2AD",
     purple: "#ECD9FF",
@@ -168,10 +167,10 @@ function CreateAtCardList() {
         );
 
         const updatedRecipients = sortedRecipients.map((recipient) => {
-          const images = recipient.recentMessages?.slice(0, 3) || []; // recentMessages가 undefined일 경우 빈 배열 반환
+          const images = recipient.recentMessages?.slice(0, 3) || [];
           const imageUrls = images
             .map((msg) => msg.profileImageURL)
-            .filter(Boolean); // undefined 방지
+            .filter(Boolean);
           return {
             ...recipient,
             profileImages: imageUrls,

--- a/src/components/domain/rollingpaper/Card/PopularCardList.jsx
+++ b/src/components/domain/rollingpaper/Card/PopularCardList.jsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import { useEffect, useState } from "react";
 import recipientsService from "../../../../api/services/recipientsService";
 import ArrowButton from "../../../common/Button/ArrowButton";
+import { useNavigate } from "react-router-dom";
 
 const BoneWrap = styled.div`
   width: 1160px;
@@ -44,6 +45,19 @@ const BackgroundWrap = styled.div.withConfig({
   color: ${({ backgroundImageURL }) =>
     backgroundImageURL ? "#ffffff;" : "#000000"};
   position: relative;
+  transition: transform 0.3s ease, box-shadow 0.3s ease,
+    background-color 0.3s ease;
+
+  &:hover {
+    transform: scale(1);
+    box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.2);
+    cursor: pointer;
+  }
+
+  &:active {
+    transform: scale(0.98);
+    box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.3);
+  }
 `;
 const TextDisplay = styled.div`
   display: flex;
@@ -114,26 +128,35 @@ const ArrowButtonDisplay = styled.div`
 `;
 
 const LeftArrowButtonDisplay = styled(ArrowButtonDisplay)`
-  position: relative;
-  right: -38px;
-  top: 118px;
+  position: absolute;
+  left: 186px; // 왼쪽에 위치하도록 설정
+  top: 23%;
+  transform: translateY(-50%);
+  z-index: 1;
+  display: ${({ show }) => (show ? "block" : "none")};
 `;
 
 const RightArrowButtonDisplay = styled(ArrowButtonDisplay)`
-  position: relative;
-  left: -38px;
-  top: 118px;
+  position: absolute;
+  right: 186px; // 오른쪽에 위치하도록 설정
+  top: 23%;
+  transform: translateY(-50%);
+  z-index: 1;
+  display: ${({ show }) => (show ? "block" : "none")};
 `;
-function PopularCardList() {
+
+function CreateAtCardList() {
   const [selectedRecipients, setSelectedRecipients] = useState([]);
   const [scrollPosition, setScrollPosition] = useState(0);
   const cardWidth = 295;
+  const navigate = useNavigate(); // useNavigate 훅 사용
   const colorMap = {
     beige: "#FFE2AD",
     purple: "#ECD9FF",
     blue: "#B1E4FF",
     green: "#D0F5C3",
   };
+
   useEffect(() => {
     const loadRecipients = async () => {
       try {
@@ -175,9 +198,21 @@ function PopularCardList() {
   const handlePrev = () => {
     setScrollPosition((prev) => (prev < 0 ? prev + 2 * cardWidth : 0));
   };
+
+  const handleCardClick = (id) => {
+    // 클릭 시 해당 id로 페이지 이동
+    navigate(`/post/${id}`);
+  };
+
+  // 좌측 버튼 숨기기 조건
+  const showLeftButton = scrollPosition !== 0;
+  // 우측 버튼 숨기기 조건
+  const showRightButton =
+    scrollPosition > -(selectedRecipients.length * cardWidth - 1160);
+
   return (
     <>
-      <LeftArrowButtonDisplay>
+      <LeftArrowButtonDisplay show={showLeftButton}>
         <ArrowButton
           direction="left"
           onClick={handlePrev}
@@ -187,10 +222,12 @@ function PopularCardList() {
       <BoneWrap>
         <BoneContainer>
           <Bone scrollPosition={scrollPosition}>
-            {selectedRecipients.map((recipient) => (
+            {selectedRecipients.map((recipient, index) => (
               <BackgroundWrap
+                key={index}
                 bgColor={colorMap[recipient.backgroundColor] || "#FFFFFF"}
                 backgroundImageURL={recipient.backgroundImageURL || null}
+                onClick={() => handleCardClick(recipient.id)} // 클릭 시 해당 id로 이동
               >
                 <div>
                   <TextDisplay>
@@ -211,7 +248,6 @@ function PopularCardList() {
                       <Avatar>+{recipient.messageCount - 3}</Avatar>
                     )}
                   </WritedContainer>
-
                   <WriteCountDisplay>
                     <WriteCount>{recipient.messageCount}</WriteCount>
                     <WritedText>명이 작성했어요!</WritedText>
@@ -222,12 +258,12 @@ function PopularCardList() {
           </Bone>
         </BoneContainer>
       </BoneWrap>
-      <RightArrowButtonDisplay>
+      <RightArrowButtonDisplay show={showRightButton}>
         <ArrowButton
           direction="right"
           onClick={handleNext}
           disabled={
-            selectedRecipients.length * cardWidth + scrollPosition <= 1160
+            scrollPosition <= -(selectedRecipients.length * cardWidth - 1160)
           }
         />
       </RightArrowButtonDisplay>
@@ -235,4 +271,4 @@ function PopularCardList() {
   );
 }
 
-export default PopularCardList;
+export default CreateAtCardList;

--- a/src/components/domain/rollingpaper/Card/PopularCardList.jsx
+++ b/src/components/domain/rollingpaper/Card/PopularCardList.jsx
@@ -1,0 +1,238 @@
+import "../../../../styles/GlobalStyles";
+import { textStyle } from "../../../../styles/textStyle";
+import styled from "styled-components";
+import { useEffect, useState } from "react";
+import recipientsService from "../../../../api/services/recipientsService";
+import ArrowButton from "../../../common/Button/ArrowButton";
+
+const BoneWrap = styled.div`
+  width: 1160px;
+  position: relative;
+  overflow: hidden;
+`;
+
+const BoneContainer = styled.div`
+  display: flex;
+  align-items: center;
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+`;
+
+const Bone = styled.div`
+  display: flex;
+  gap: 20px;
+  width: fit-content;
+  transition: transform 0.5s ease;
+  transform: translateX(${(props) => props.scrollPosition}px);
+`;
+
+const BackgroundWrap = styled.div.withConfig({
+  shouldForwardProp: (prop) =>
+    !["bgColor", "backgroundImageURL"].includes(prop),
+})`
+  background-color: ${({ bgColor }) => bgColor || "#FFFFFF"};
+  background-image: ${({ backgroundImageURL }) =>
+    backgroundImageURL ? `url(${backgroundImageURL})` : "none"};
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  width: 275px;
+  height: 260px;
+  padding: 30px 24px;
+  border-radius: 1rem;
+  color: ${({ backgroundImageURL }) =>
+    backgroundImageURL ? "#ffffff;" : "#000000"};
+  position: relative;
+`;
+const TextDisplay = styled.div`
+  display: flex;
+  height: 36px;
+  margin-bottom: 0.75rem;
+`;
+
+const ToText = styled.div`
+  ${(props) => textStyle(24, 700)(props)}
+  margin-bottom: 0.75rem;
+  height: 2.625rem;
+`;
+
+const WritedContainer = styled.div`
+  display: inline-flex;
+  align-items: center;
+`;
+
+const Avatar = styled.div`
+  ${(props) => textStyle(12, 400)(props)}
+  right: -6px;
+  position: relative;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background-color: white;
+  border: 1px solid ${({ theme }) => theme.colors.grayScale[200]};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: -10px;
+  margin-bottom: 0.75rem;
+
+  img {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+  }
+
+  &:not(:has(img)) {
+    background-color: white;
+    color: ${({ theme }) => theme.colors.grayScale[800]};
+  }
+`;
+
+const WriteCount = styled.div`
+  font-size: 16px;
+  font-weight: 600;
+`;
+
+const WriteCountDisplay = styled.div`
+  display: flex;
+  align-items: center;
+  ${(props) => textStyle(16, 700)(props)}
+`;
+
+const WritedText = styled.div`
+  font-size: 14px;
+`;
+
+const ArrowButtonDisplay = styled.div`
+  display: flex;
+  align-items: center;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 1;
+`;
+
+const LeftArrowButtonDisplay = styled(ArrowButtonDisplay)`
+  position: relative;
+  right: -38px;
+  top: 118px;
+`;
+
+const RightArrowButtonDisplay = styled(ArrowButtonDisplay)`
+  position: relative;
+  left: -38px;
+  top: 118px;
+`;
+function PopularCardList() {
+  const [selectedRecipients, setSelectedRecipients] = useState([]);
+  const [scrollPosition, setScrollPosition] = useState(0);
+  const cardWidth = 295;
+  const colorMap = {
+    beige: "#FFE2AD",
+    purple: "#ECD9FF",
+    blue: "#B1E4FF",
+    green: "#D0F5C3",
+  };
+  useEffect(() => {
+    const loadRecipients = async () => {
+      try {
+        const response = await recipientsService.getRecipients(
+          "/14-8/recipients/"
+        );
+        const sortedRecipients = response.data.results.sort(
+          (a, b) => b.messageCount - a.messageCount
+        );
+
+        const updatedRecipients = sortedRecipients.map((recipient) => {
+          const images = recipient.recentMessages?.slice(0, 3) || []; // recentMessages가 undefined일 경우 빈 배열 반환
+          const imageUrls = images
+            .map((msg) => msg.profileImageURL)
+            .filter(Boolean); // undefined 방지
+          return {
+            ...recipient,
+            profileImages: imageUrls,
+          };
+        });
+
+        console.log(updatedRecipients);
+        setSelectedRecipients(updatedRecipients);
+      } catch (error) {
+        console.error("받는 사람 데이터를 가져오지 못했습니다:", error);
+      }
+    };
+
+    loadRecipients();
+  }, []);
+
+  const handleNext = () => {
+    const maxScroll = -(selectedRecipients.length * cardWidth - 1160);
+    setScrollPosition((prev) =>
+      prev > maxScroll ? prev - 2 * cardWidth : maxScroll
+    );
+  };
+
+  const handlePrev = () => {
+    setScrollPosition((prev) => (prev < 0 ? prev + 2 * cardWidth : 0));
+  };
+  return (
+    <>
+      <LeftArrowButtonDisplay>
+        <ArrowButton
+          direction="left"
+          onClick={handlePrev}
+          disabled={scrollPosition === 0}
+        />
+      </LeftArrowButtonDisplay>
+      <BoneWrap>
+        <BoneContainer>
+          <Bone scrollPosition={scrollPosition}>
+            {selectedRecipients.map((recipient) => (
+              <BackgroundWrap
+                bgColor={colorMap[recipient.backgroundColor] || "#FFFFFF"}
+                backgroundImageURL={recipient.backgroundImageURL || null}
+              >
+                <div>
+                  <TextDisplay>
+                    <ToText>To.</ToText>
+                    <ToText>
+                      {recipient.name === "Unknown"
+                        ? "이름 없음"
+                        : recipient.name}
+                    </ToText>
+                  </TextDisplay>
+                  <WritedContainer>
+                    {recipient.profileImages?.slice(0, 3).map((url, i) => (
+                      <Avatar key={i}>
+                        <img src={url} alt={`프로필 이미지 ${i + 1}`} />
+                      </Avatar>
+                    ))}
+                    {recipient.messageCount > 3 && (
+                      <Avatar>+{recipient.messageCount - 3}</Avatar>
+                    )}
+                  </WritedContainer>
+
+                  <WriteCountDisplay>
+                    <WriteCount>{recipient.messageCount}</WriteCount>
+                    <WritedText>명이 작성했어요!</WritedText>
+                  </WriteCountDisplay>
+                </div>
+              </BackgroundWrap>
+            ))}
+          </Bone>
+        </BoneContainer>
+      </BoneWrap>
+      <RightArrowButtonDisplay>
+        <ArrowButton
+          direction="right"
+          onClick={handleNext}
+          disabled={
+            selectedRecipients.length * cardWidth + scrollPosition <= 1160
+          }
+        />
+      </RightArrowButtonDisplay>
+    </>
+  );
+}
+
+export default PopularCardList;

--- a/src/pages/CreateRollingPaper/CreateRollingPaperPage.jsx
+++ b/src/pages/CreateRollingPaper/CreateRollingPaperPage.jsx
@@ -1,23 +1,19 @@
 import Input from "../../components/common/Input/Input/Input";
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 function CreateRollingPaperPage() {
   return (
-    <>
-      <Bone>
-        <Input />
-      </Bone>
-    </>
+    <Bone>
+      <Input />
+    </Bone>
   );
 }
 
 export default CreateRollingPaperPage;
 
-const flexCenter = css`
+const Bone = styled.div`
   display: flex;
   justify-content: center;
-  align-items: center;
-`;
-
-const Bone = styled.div`
-  ${flexCenter}
+  background-color: #ffffff;
+  padding: 57px 600px;
+  min-height: calc(100vh - 65px);
 `;

--- a/src/pages/Message/MessagePage.jsx
+++ b/src/pages/Message/MessagePage.jsx
@@ -4,7 +4,9 @@ import styled from "styled-components";
 const Bone = styled.div`
   display: flex;
   justify-content: center;
-  align-items: center;
+  background-color: #ffffff;
+  padding: 47px 600px;
+  min-height: calc(100vh - 65px);
 `;
 
 function MessagePage() {

--- a/src/pages/RollingPaper/RollingPaperPage.jsx
+++ b/src/pages/RollingPaper/RollingPaperPage.jsx
@@ -159,11 +159,13 @@ function RollingPaperDetailPage() {
         <DivWrap>
           <Card postData={postData} />
           {messages?.map((message) => (
-            <CardWrite
-              key={message.id}
-              message={message}
-              fontFamily={message.font}
-            />
+            <div key={message.id}>
+              <CardWrite
+                key={message.id}
+                message={message}
+                fontFamily={message.font}
+              />
+            </div>
           ))}
           {messages?.length > 0 && <div id="last-card"></div>}
         </DivWrap>

--- a/src/pages/RollingPaper/RollingPaperPage.jsx
+++ b/src/pages/RollingPaper/RollingPaperPage.jsx
@@ -46,6 +46,7 @@ function RollingPaperDetailPage() {
     green: "#D0F5C3",
   };
 
+  // 무한 스크롤 때 사용합니다다
   const observer = useRef(null);
 
   // API 호출 함수
@@ -116,7 +117,7 @@ function RollingPaperDetailPage() {
     }
   }, [page, loading]);
 
-  // 밑에 스크롤 할 수 있음음
+  // 밑에 무한 스크롤 할 수 있음
   useEffect(() => {
     if (!observer.current) {
       observer.current = new IntersectionObserver(

--- a/src/pages/RollingPaperList/RollingPaperListPage.jsx
+++ b/src/pages/RollingPaperList/RollingPaperListPage.jsx
@@ -25,7 +25,6 @@ const Title = styled.div`
   display: flex;
   width: -webkit-fill-available;
   justify-content: left;
-  padding-left: 66px;
 `;
 
 const ButtonWrapper = styled.div`

--- a/src/pages/RollingPaperList/RollingPaperListPage.jsx
+++ b/src/pages/RollingPaperList/RollingPaperListPage.jsx
@@ -1,20 +1,76 @@
 import { useNavigate } from "react-router-dom";
+import CreateAtCardList from "../../components/domain/rollingpaper/Card/CreateAtCardList";
+import styled from "styled-components";
+import PopularCardList from "../../components/domain/rollingpaper/Card/PopularCardList";
+import Button from "../../components/common/Button/Button";
+
+const Container = styled.div`
+  background-color: #ffffff;
+`;
+const PageWrapper = styled.div`
+  padding: 50px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: start;
+  min-height: calc(100vh - 65px);
+  width: max-content;
+  margin: auto;
+`;
+
+const Title = styled.div`
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin-bottom: 10px;
+  display: flex;
+  width: -webkit-fill-available;
+  justify-content: left;
+  padding-left: 66px;
+`;
+
+const ButtonWrapper = styled.div`
+  margin-top: 20px;
+  display: flex;
+  justify-content: center;
+`;
+
+const StyledCardList = styled.div`
+  display: flex;
+  gap: 20px;
+  margin-bottom: 50px;
+  width: max-content;
+`;
 
 function RollingPaperListPage() {
   const navigate = useNavigate();
 
   return (
-    <div>
-      <h1>롤링페이퍼 목록</h1>
+    <Container>
+      <PageWrapper>
+        <Title>인기 롤링 페이퍼🔥</Title>
 
-      <div>
-        <h3>생성된 카드</h3>
+        <StyledCardList>
+          <PopularCardList />
+        </StyledCardList>
 
-        <button onClick={() => navigate("/post/1")}>첫 번째 카드</button>
+        <Title>최근에 만든 롤링 페이퍼⭐</Title>
 
-      </div>
-      <button onClick={() => navigate(`/post`)}>나도 만들어보기</button>
-    </div>
+        <StyledCardList>
+          <CreateAtCardList />
+        </StyledCardList>
+
+        <ButtonWrapper>
+          <Button
+            variant="primary"
+            size="56"
+            width="280"
+            onClick={() => navigate(`/post`)}
+          >
+            나도 만들어보기
+          </Button>
+        </ButtonWrapper>
+      </PageWrapper>
+    </Container>
   );
 }
 


### PR DESCRIPTION
# 🚀 Pull Request
- [x] '로고' 버튼을 클릭하면 / 페이지로 이동합니다.
- [x] '롤링 페이퍼 만들기' 버튼을 클릭하면 /post 페이지로 이동합니다.
- [x] '나도 만들어보기' 버튼을 클릭하면 /post 페이지로 이동합니다.
- [x] 생성된 카드를 클릭하면 /post{id} 페이지로 이동합니다
- [x] PC에서 롤링 페이퍼 카드 목록 영역의 너비는 고정합니다.
- [x] PC에서 좌/우측 버튼 클릭 시 다음 순서의 롤링 페이퍼 카드들이 보입니다.
- [x] PC에서 첫 순서일 때는 좌측 버튼이 보이지 않고, 마지막 순서일 때는 우측 버튼이 보이지 않습니다.
- [x] 롤링 페이퍼 카드의 개수가 4개보다 적을 때 좌측부터 채워지고, 좌/우측 버튼은 보이지 않습니다.
- [ ] Tablet에서 롤링 페이퍼 카드 목록 영역이 화면의 너비를 넘어갈 경우 터치로 좌우 스크롤 가능합니다.
- [ ] Tablet에서 상단 네비게이션은 좌우 여백은 24px로 고정하고 '로고'와 '롤링 페이퍼 만들기' 버튼의 간격이 줄어들거나 커집니다.
- [ ] Mobile에서 롤링 페이퍼 카드 목록 영역이 화면의 너비를 넘어갈 경우 터치로 좌우 스크롤 가능합니다.
## 📝 PR 유형

<!-- 해당하는 유형에 'x'로 체크해주세요 -->

- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항
Button 컴포넌트 arrow 조금 더 투명하게만 바꿨어요.🫠
<!-- 이 PR에서 무엇이 변경되었는지 간략하게 설명해주세요 -->

## 📸 스크린샷
![이모티콘제외](https://github.com/user-attachments/assets/e9531c26-182b-4843-a0d1-831a46b795de)

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## 🛠️ 테스트 방법

<!-- 이 기능을 테스트하는 방법을 설명해주세요 -->

1. 
2.
3.

## 🚧 관련 이슈

<!-- 관련 이슈 번호가 있다면 적어주세요 (e.g. #123 또는 ISSUE-123 과 같은 JIRA key) -->

## 💡 추가 정보
1. 이모티콘이 추가될 예정이에요잉~~
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요 -->

## 🙏 리뷰어에게

<!-- 리뷰어에게 특별히 확인받고 싶은 부분이 있다면 언급해주세요 -->
